### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -10,7 +10,7 @@
         "statistics",
         "visualization stats"
     ],
-    "docker_image": "supervisely/visualization-stats:0.0.5",
+    "docker_image": "supervisely/visualization-stats:6.73.564",
     "icon": "https://user-images.githubusercontent.com/12828725/183916661-224ff8cb-a3d1-4b82-a629-def8c6de1db5.png",
     "poster": "https://user-images.githubusercontent.com/106374579/187223426-ec7e0fae-8ba9-48fd-b71f-8680cc0f1b49.png",
     "entrypoint": "python -m uvicorn src.main:app --host 0.0.0.0 --port 8000",

--- a/config.json
+++ b/config.json
@@ -1,25 +1,25 @@
 {
-    "type": "app",
-    "version": "2.0.0",
-    "name": "Interactive objects distribution",
-    "description": "Explore images with certain number of objects of specific class",
-    "categories": [
-        "images",
-        "visualization",
-        "exploration",
-        "statistics",
-        "visualization stats"
+  "type": "app",
+  "version": "2.0.0",
+  "name": "Interactive objects distribution",
+  "description": "Explore images with certain number of objects of specific class",
+  "categories": [
+    "images",
+    "visualization",
+    "exploration",
+    "statistics",
+    "visualization stats"
+  ],
+  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
+  "icon": "https://user-images.githubusercontent.com/12828725/183916661-224ff8cb-a3d1-4b82-a629-def8c6de1db5.png",
+  "poster": "https://user-images.githubusercontent.com/106374579/187223426-ec7e0fae-8ba9-48fd-b71f-8680cc0f1b49.png",
+  "entrypoint": "python -m uvicorn src.main:app --host 0.0.0.0 --port 8000",
+  "port": 8000,
+  "context_menu": {
+    "target": [
+      "images_project"
     ],
-    "docker_image": "supervisely/visualization-stats:6.73.564",
-    "icon": "https://user-images.githubusercontent.com/12828725/183916661-224ff8cb-a3d1-4b82-a629-def8c6de1db5.png",
-    "poster": "https://user-images.githubusercontent.com/106374579/187223426-ec7e0fae-8ba9-48fd-b71f-8680cc0f1b49.png",
-    "entrypoint": "python -m uvicorn src.main:app --host 0.0.0.0 --port 8000",
-    "port": 8000,
-    "context_menu": {
-        "target": [
-            "images_project"
-        ],
-        "context_root": "Report"
-    },
-    "instance_version": "6.15.60"
+    "context_root": "Report"
+  },
+  "instance_version": "6.15.60"
 }

--- a/config.json
+++ b/config.json
@@ -21,5 +21,5 @@
         ],
         "context_root": "Report"
     },
-    "min_instance_version": "6.5.22"
+    "instance_version": "6.15.60"
 }

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,1 +1,1 @@
-supervisely==6.72.55
+supervisely==6.73.564


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Does not release applications.

Validation: generated ecosystem inventory report.
